### PR TITLE
reduce CPU usage from constant polling

### DIFF
--- a/plover_stenograph/base.py
+++ b/plover_stenograph/base.py
@@ -113,6 +113,7 @@ class StenographMachine(ThreadedStenotypeBase):
                 if response.data_length and state.realtime:
                     for stroke in response.strokes():
                         self._on_stroke(stroke.keys)
+                sleep(0.10)
 
         self._transport.disconnect()
 


### PR DESCRIPTION
On my computer, plover is one of the most resource intensive processes when using this plugin.
This is because the USB polling occurs in a loop with no sleep.
The code as it was, polled for USB information in excess of 1600 times a second.
This commit adds in a sleep to reduce that down to around 10 polls a second.
A sleep of 0.10 seconds was chosen as this in excess of 5 strokes per second - the fastest I could find, -33% to account for peaks.
Additionally, the delay doesn't introduce significant lag to realtime output.