### PR TITLE
Fix compatibility with latest version of more-itertools

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ setup_requires =
   setuptools>=30.3.0
 install_requires =
   plover>=4.0.0.dev10
-  more_itertools
+  more_itertools>=6.0.0
   pyusb>=1.0.0  ; platform_system != "Windows"
   pyusb_libusb1_backend  ; platform_system != "Windows"
 packages =

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,15 +11,15 @@ classifiers =
 [options]
 zip_safe = True
 setup_requires =
-	setuptools>=30.3.0
+  setuptools>=30.3.0
 install_requires =
-	plover>=4.0.0.dev10
+  plover>=4.0.0.dev10
   more_itertools
   pyusb>=1.0.0  ; platform_system != "Windows"
   pyusb_libusb1_backend  ; platform_system != "Windows"
 packages =
   stenograph
-	plover_stenograph
+  plover_stenograph
 
 [options.entry_points]
 plover.machine =

--- a/stenograph/packet.py
+++ b/stenograph/packet.py
@@ -150,5 +150,5 @@ class StenoPacket:
 
         return [
             Stroke.unpack(stroke_data)
-            for stroke_data in grouper(8, self.data, 0)
+            for stroke_data in grouper(self.data, 8, fillvalue=0)
         ]


### PR DESCRIPTION
Right now, you need to manually fix this in stenograph/packet.py when installing from the plugin manager.